### PR TITLE
Update jsdom version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "html-loader": "0.3.0",
     "html-webpack-plugin": "1.6.1",
     "jasmine-core": "2.4.1",
-    "jsdom": "1.0.0-pre.6",
+    "jsdom": "^1.0.0-pre.6",
     "karma": "^0.13.19",
     "karma-firefox-launcher": "0.1.7",
     "karma-jasmine": "^0.3.6",


### PR DESCRIPTION
~~closes #40~~ becoming increasingly skeptical that this won't solve the original issue described in #40  BUT  that's not a reason we can't use a modern version of the dep

tests pass, behavior is identical