### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "url": "https://github.com/cshinn/patternfly-timeline"
   },
   "dependencies": {
-    "d3": "3.5.3",
-    "patternfly": "~3.7.0"
+    "d3": "3.5.17",
+    "patternfly": "~3.25.0"
   },
   "devDependencies": {
     "babel-core": "6.4.5",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/cshinn/patternfly-timeline"
   },
   "dependencies": {
-    "d3": "3.5.17",
+    "d3": "~3.5.17",
     "patternfly": "~3.25.0"
   },
   "devDependencies": {


### PR DESCRIPTION
@jeff-phillips-18 @allenbw

This allows webpack 2.0 and 3.0 to use patternfly-timeline without bringing in all of the jsdom dependencies.