### PR TITLE
Remove noisy console.log

### DIFF
--- a/src/zoom.js
+++ b/src/zoom.js
@@ -47,7 +47,6 @@ export default class zoom {
           .attr('id', 'timeline-pf-zoom-out')
           .style('top', `${configuration.padding.top + dimensions.height - 26}px`)
           .on('click', () => {this.zoomClick()});
-          console.log(zoomIn.node().offsetWidth);
       zoomOut
         .style('left', `${configuration.padding.left + configuration.labelWidth + dimensions.width + (configuration.sliderWidth - zoomOut.node().offsetWidth)}px`)
         .append('i')


### PR DESCRIPTION
Propose we remove this, consumers of pf-timeline don't need the noise of the console.log statement (it appears to have been used for debugging in the past)